### PR TITLE
Don't draw from empty strategy

### DIFF
--- a/src/hypothesis_jsonschema/_impl.py
+++ b/src/hypothesis_jsonschema/_impl.py
@@ -384,7 +384,8 @@ def object_schema(schema: dict) -> st.SearchStrategy[Dict[str, JSONType]]:
                                 break
                         break
                 else:
-                    out[key] = draw(from_schema(additional))
+                    if additional is not False:
+                        out[key] = draw(from_schema(additional))
             for k, v in dep_schemas.items():
                 if k in out and not is_valid(out, v):
                     out.pop(key)


### PR DESCRIPTION
When a schema has `"additionalProperties": false` in many places, drawing from empty strategies causes hypothesis to mark conjecture data as invalid. That affects the health checks.

As a side effect of the change, the execution time for my schema dropped three times.