### PR TITLE
Implement references

### DIFF
--- a/src/hypothesis_jsonschema/_impl.py
+++ b/src/hypothesis_jsonschema/_impl.py
@@ -526,8 +526,8 @@ class StrategyFactory:
         else:
             type_ = []
             for t, kw in [
-                ("number", "multipleOf maximum exclusiveMaximum minimum exclusiveMinimum"),
-                ("integer", "multipleOf maximum exclusiveMaximum minimum exclusiveMinimum"),
+                ("number", "multipleOf maximum exclusiveMaximim minimum exclusiveMinimum"),
+                ("integer", "multipleOf maximum exclusiveMaximim minimum exclusiveMinimum"),
                 ("string", "maxLength minLength pattern contentEncoding contentMediaType"),
                 ("array", "items additionalItems maxItems uniqueItems contains"),
                 (


### PR DESCRIPTION
This implements references and speeds up the validation by letting jsonschema validate the schema only once. Also there is a minor fix of the `maximim` typo.

Most of the changes are moving the functions into the new class `StrategyFactory`. That allows access to the original schema from any location and enables the references.