### PR TITLE
Handle unsatisfiable schema case when numeric range does not contain any numbers divisible by `multipleOf`

### DIFF
--- a/tests/test_canonicalise.py
+++ b/tests/test_canonicalise.py
@@ -72,15 +72,12 @@ def test_canonicalises_to_equivalent_fixpoint(schema_strategy, data):
         {"type": "integer", "minimum": 2, "maximum": 1},
         {"type": "integer", "minimum": 1, "maximum": 2, "multipleOf": 3},
         {"type": "number", "exclusiveMinimum": 0, "maximum": 0},
-        pytest.param(
-            {
-                "type": "number",
-                "exclusiveMinimum": 0,
-                "exclusiveMaximum": 3,
-                "multipleOf": 3,
-            },
-            marks=pytest.mark.xfail,
-        ),
+        {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "exclusiveMaximum": 3,
+            "multipleOf": 3,
+        },
     ],
 )
 def test_canonicalises_to_empty(schema):


### PR DESCRIPTION
Similar logic should apply to `integer` type as far as I can see. What do you think? will this approach work? If yes, then I can extend it to integers as well :)

Also, I am not sure about correct wording in the variable names & docstrings

Regards