### PR TITLE
Handle more (additional)items, contains, properties in ref replacement

### DIFF
--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -53,6 +53,7 @@ SCHEMA_OBJECT_KEYS = ("properties", "patternProperties", "dependencies")
 # Names of schema keys that might need extra $ref discovery
 SCHEMA_NESTED_REF_KEYS = ("items", "additionalItems", "contains")
 
+
 def is_valid(instance: JSONType, schema: Schema) -> bool:
     try:
         jsonschema.validate(instance, schema)

--- a/tests/gen_schemas.py
+++ b/tests/gen_schemas.py
@@ -153,12 +153,20 @@ def gen_array(draw: Any) -> Schema:
     else:
         if draw(st.booleans()):
             out["uniqueItems"] = True
+            if isinstance(items, dict):
+                for min_ in ["minimum", "exclusiveMinimum"]:
+                    for max_ in ["maximum", "exclusiveMaximum"]:
+                        if min_ not in items or max_ not in items:
+                            continue
+                        if items[min_] == items[max_]:
+                            assume(min_size < 2)
         if items == {}:
             out["contains"] = draw(_json_schemata(recur=False))
     if min_size is not None:
         out["minItems"] = min_size
     if max_size is not None:
         out["maxItems"] = max_size
+
     return out
 
 

--- a/tests/test_from_schema.py
+++ b/tests/test_from_schema.py
@@ -227,9 +227,41 @@ REF_IN_ARRAY_ITEMS = {
 }
 
 
-@pytest.mark.xfail(
-    strict=True, reason="https://github.com/Zac-HD/hypothesis-jsonschema/issues/32"
-)
 @given(from_schema(REF_IN_ARRAY_ITEMS))
 def test_ref_in_array_items(value):
     jsonschema.validate(value, REF_IN_ARRAY_ITEMS)
+
+
+REF_IN_ARRAY_ADDITIONAL_ITEMS = {
+    "type": "object",
+    "definition": {"type": "string"},
+    "properties": {
+        "something-else": {
+            "type": "array",
+            "items": [{"type": "number"}],
+            "additionalItems": {"$ref": "#/definition"}
+        }
+    },
+    "additionalProperties": False,
+}
+
+@given(from_schema(REF_IN_ARRAY_ADDITIONAL_ITEMS))
+def test_ref_in_array_additional_items(value):
+    jsonschema.validate(value, REF_IN_ARRAY_ADDITIONAL_ITEMS)
+
+
+REF_IN_ARRAY_CONTAINS = {
+    "type": "object",
+    "definition": {"type": "string"},
+    "properties": {
+        "something": {
+            "type": "array",
+            "contains": {"$ref": "#/definition"}
+        }
+    },
+    "additionalProperties": False,
+}
+
+@given(from_schema(REF_IN_ARRAY_CONTAINS))
+def test_ref_in_array_contains(value):
+    jsonschema.validate(value, REF_IN_ARRAY_CONTAINS)

--- a/tests/test_from_schema.py
+++ b/tests/test_from_schema.py
@@ -239,11 +239,12 @@ REF_IN_ARRAY_ADDITIONAL_ITEMS = {
         "something-else": {
             "type": "array",
             "items": [{"type": "number"}],
-            "additionalItems": {"$ref": "#/definition"}
+            "additionalItems": {"$ref": "#/definition"},
         }
     },
     "additionalProperties": False,
 }
+
 
 @given(from_schema(REF_IN_ARRAY_ADDITIONAL_ITEMS))
 def test_ref_in_array_additional_items(value):
@@ -254,13 +255,11 @@ REF_IN_ARRAY_CONTAINS = {
     "type": "object",
     "definition": {"type": "string"},
     "properties": {
-        "something": {
-            "type": "array",
-            "contains": {"$ref": "#/definition"}
-        }
+        "something": {"type": "array", "contains": {"$ref": "#/definition"}}
     },
     "additionalProperties": False,
 }
+
 
 @given(from_schema(REF_IN_ARRAY_CONTAINS))
 def test_ref_in_array_contains(value):

--- a/tests/test_from_schema.py
+++ b/tests/test_from_schema.py
@@ -270,9 +270,13 @@ def test_ref_in_array_additional_items(value):
 
 REF_IN_ARRAY_CONTAINS = {
     "type": "object",
-    "definition": {"type": "string"},
+    "definition": {"type": "string", "pattern": "\\d"},
     "properties": {
-        "something": {"type": "array", "contains": {"$ref": "#/definition"}}
+        "something": {
+            "type": "array",
+            "items": {"type": "string"},
+            "contains": {"$ref": "#/definition"},
+        }
     },
     "additionalProperties": False,
 }


### PR DESCRIPTION
First off, thanks for this great tool! Really looking forward to leveraging this `$ref` stuff once it gets squared away. Thanks for the thoughts on #32 as to what the goals of the ref removal should be, and why I was seeing many RefResolvers being created.

It _looked_ like the main change here to `resolve_all_refs` would be done outside of `res_one`, but there was no way I could slice it to make it fully resolve. Perhaps you have some more insight.

I don't use `contains` much, nor have I seen it used much, but seemed like testing something for four similar properties made more sense than stopping at three... but the test added for it appears to flake with `Cannot create non-empty lists with elements drawn from strategy nothing() because it has no values.`. Have tried a few things, and it _has_ come up green, but who knows what will happen on CI.

I was going to leave off on the `xfail` stuff, but curiosity killed the cat, and I put that in as well, which lead to some further simplification of the overall approach. The avro fixture was the only surprising one, as it doesn't merge properly, but that seemed further than I wanted to dive. The before/after is:
```
====== 1 failed, 412 passed, 29 skipped, 111 xfailed in 244.95s (0:04:04) ======
```
vs
```
=========== 432 passed, 32 skipped, 90 xfailed in 266.28s (0:04:26) ============
```
which seems like a decent direction to be moving, even if a few things just went from xfail to skip.

The `gen_schema` change wasn't appearing on travis, but was failing locally... I can pull it out if it's not relevant, or just related to dependency drift on my part.

Thanks again!