### PR TITLE
Improved canonicalisation of `uniqueItems: false` case

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ support, roadmap input, and prioritized feature development.
 
 ### Changelog:
 
+- Improved canonicalisation of `uniqueItems: false` case
+
 #### 0.12.1 - 2020-04-14
 - Added a strategy for the `"color"` format
 - Only apply string length filter when needed (small performance improvement)

--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -466,6 +466,8 @@ def canonicalish(schema: JSONType) -> Dict[str, Any]:
         schema.pop("else", None)
     if "then" not in schema and "else" not in schema:
         schema.pop("if", None)
+    if schema.get("uniqueItems") is False:
+        del schema["uniqueItems"]
     return schema
 
 

--- a/tests/test_canonicalise.py
+++ b/tests/test_canonicalise.py
@@ -138,6 +138,7 @@ def test_canonicalises_to_empty(schema):
             {"minItems": 1, "type": "array"},
         ),
         ({"anyOf": [{}, {"type": "null"}]}, {}),
+        ({"uniqueItems": False}, {}),
     ],
 )
 def test_canonicalises_to_expected(schema, expected):


### PR DESCRIPTION
Hi!

As I noticed in #15, this is one of the remaining cases