### PR TITLE
Reuse `jsonschema` validators during canonicalisation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install dependencies
       run: python -m pip install --upgrade pip setuptools tox
     - name: Run tests
-      run: python -m tox --recreate -e test -- -n auto
+      run: python -m tox --recreate -e test
 
   release:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ support, roadmap input, and prioritized feature development.
 ### Changelog:
 
 - Improved canonicalisation of `uniqueItems: false` case
+- Reuse `jsonschema` validators during canonicalisation (performance improvement)
 
 #### 0.12.1 - 2020-04-14
 - Added a strategy for the `"color"` format

--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -51,14 +51,6 @@ SCHEMA_KEYS = tuple(
 SCHEMA_OBJECT_KEYS = ("properties", "patternProperties", "dependencies")
 
 
-def is_valid(instance: JSONType, schema: Schema) -> bool:
-    try:
-        jsonschema.validate(instance, schema)
-        return True
-    except jsonschema.ValidationError:
-        return False
-
-
 def make_validator(
     schema: Schema,
 ) -> Union[
@@ -234,7 +226,7 @@ def canonicalish(schema: JSONType) -> Dict[str, Any]:
     # Make a copy, so we don't mutate the existing schema in place.
     schema = dict(schema)
     if "const" in schema:
-        if not is_valid(schema["const"], schema):
+        if not make_validator(schema).is_valid(schema["const"]):
             return FALSEY
         return {"const": schema["const"]}
     if "enum" in schema:
@@ -568,8 +560,7 @@ def merged(schemas: List[Any]) -> Optional[Schema]:
         s = canonicalish(s)
         # If we have a const or enum, this is fairly easy by filtering:
         if "const" in s:
-            validator = make_validator(out)
-            if validator.is_valid(s["const"], out):
+            if make_validator(out).is_valid(s["const"]):
                 out = s
                 continue
             return FALSEY

--- a/tests/test_canonicalise.py
+++ b/tests/test_canonicalise.py
@@ -15,11 +15,15 @@ from hypothesis_jsonschema._canonicalise import (
     canonicalish,
     encode_canonical_json,
     get_type,
-    is_valid,
+    make_validator,
     merged,
     resolve_all_refs,
 )
 from hypothesis_jsonschema._from_schema import JSON_STRATEGY
+
+
+def is_valid(instance, schema):
+    return make_validator(schema).is_valid(instance)
 
 
 @given(JSON_STRATEGY)

--- a/tests/test_canonicalise.py
+++ b/tests/test_canonicalise.py
@@ -39,7 +39,12 @@ def test_canonicalises_to_equivalent_fixpoint(schema_strategy, data):
     schema = data.draw(schema_strategy, label="schema")
     cc = canonicalish(schema)
     assert cc == canonicalish(cc)
-    instance = data.draw(JSON_STRATEGY | from_schema(cc), label="instance")
+    try:
+        strat = from_schema(cc)
+    except InvalidArgument:
+        # e.g. array of unique {type: integers}, with too few allowed integers
+        assume(False)
+    instance = data.draw(JSON_STRATEGY | strat, label="instance")
     assert is_valid(instance, schema) == is_valid(instance, cc)
     jsonschema.validators.validator_for(schema).check_schema(schema)
 
@@ -93,6 +98,15 @@ def test_canonicalises_to_equivalent_fixpoint(schema_strategy, data):
             "required": ["", "0"],
             "propertyNames": {"minLength": 2},
         },
+        pytest.param(
+            {
+                "type": "array",
+                "items": {"type": "integer", "minimum": 0, "maximum": 0},
+                "uniqueItems": True,
+                "minItems": 2,
+            },
+            marks=pytest.mark.xfail,
+        ),
     ],
 )
 def test_canonicalises_to_empty(schema):
@@ -280,7 +294,12 @@ def _canonicalises_to_equivalent_fixpoint(data):
     schema = data.draw(json_schemata(), label="schema")
     cc = canonicalish(schema)
     assert cc == canonicalish(cc)
-    instance = data.draw(JSON_STRATEGY | from_schema(cc), label="instance")
+    try:
+        strat = from_schema(cc)
+    except InvalidArgument:
+        # e.g. array of unique {type: integers}, with too few allowed integers
+        assume(False)
+    instance = data.draw(JSON_STRATEGY | strat, label="instance")
     assert is_valid(instance, schema) == is_valid(instance, cc)
     jsonschema.validators.validator_for(schema).check_schema(schema)
 

--- a/tests/test_from_schema.py
+++ b/tests/test_from_schema.py
@@ -77,6 +77,7 @@ FLAKY_SCHEMAS = {
     # Occasionally really slow
     "snapcraft project  (https://snapcraft.io)",
     "batect configuration file",
+    "UI5 Tooling Configuration File (ui5.yaml)",
     # Sometimes unsatisfiable.  TODO: improve canonicalisation to remove filters
     "Drone CI configuration file",
     "PHP Composer configuration file",

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     --requirement deps/test.txt
 commands =
     pip install --no-deps --editable .
-    pytest {posargs}
+    pytest {posargs:-n auto}
 
 [testenv:deps]
 description = Updates test corpora and the pinned dependencies in `deps/*.txt`


### PR DESCRIPTION
A part of #36

I made some benchmarks on my machine to have a better performance overview.
Benchmark code:

```
import timeit

ITERATIONS = 1000
setup = "from hypothesis_jsonschema._canonicalise import canonicalish"

def bench(name, schema):
    result = timeit.timeit(
        "canonicalish(schema)", f"{setup}\nschema = {schema}", number=ITERATIONS
    )
    print(f"{name} => {result:.5f}")

ENUM_SMALL = {"enum": [1]}
ENUM_BIG = {"enum": list(range(100))}
REQUIRED_PROPERTY_NAMES_SMALL = {
    "required": ["x-a"],
    "propertyNames": {"pattern": "^x-"},
}
REQUIRED_PROPERTY_NAMES_BIGGER = {
    "required": [f"x-{letter}" for letter in "abcdefghij"],
    "propertyNames": {"pattern": "^x-"},
}
ALL_OF_CONST_SMALL = {"allOf": [{"const": 1}]}
ALL_OF_CONST_BIGGER = {"allOf": [{"const": 1} for _ in range(100)]}
ALL_OF_ENUM_SMALL = {"allOf": [{"enum": [1]}]}
ALL_OF_ENUM_BIGGER = {"allOf": [{"enum": list(range(10))} for _ in range(10)]}


if __name__ == "__main__":
    bench("Small enum", ENUM_SMALL)
    bench("Big enum", ENUM_BIG)
    bench("Small required + propertyNames", REQUIRED_PROPERTY_NAMES_SMALL)
    bench("Bigger required + propertyNames", REQUIRED_PROPERTY_NAMES_BIGGER)
    bench("Small allOf + const", ALL_OF_CONST_SMALL)
    bench("Bigger allOf + const", ALL_OF_CONST_BIGGER)
    bench("Small allOf + enum", ALL_OF_ENUM_SMALL)
    bench("Bigger allOf + enum", ALL_OF_ENUM_BIGGER)
```

It doesn't cover all possible use-cases but I believe it can provide at least some rough estimations on the performance impact.

The results:

Schema | Before | After | Ratio
------------|----------|--------|---------
ENUM_SMALL | 0.08228 | 0.02833 | **x2.9**
ENUM_BIG | 11.39246 | 0.20190 | **x56.42**
REQUIRED_PROPERTY_NAMES_SMALL | 0.12566 | 0.07237 | **x1.73**
REQUIRED_PROPERTY_NAMES_BIGGER | 0.80882 | 0.10158 | **x7.96**
ALL_OF_CONST_SMALL | 0.10944 | 0.10932 | **~x1**
ALL_OF_CONST_BIGGER | 22.27539 | 17.73757 | **x1.25**
ALL_OF_ENUM_SMALL | 0.12382 | 0.11855 | **x1.04**
ALL_OF_ENUM_BIGGER | 25.97481 | 16.76330 | **x1.54**

Ratios depend on the number of iterations, so the actual impact might be different, but the performance is at least the same in the edge cases or faster even for 1 iteration. I believe it is because `validator.is_valid` does fewer steps in comparison with the current `is_valid` implementation in `_canonicalise.py` (no `best_match` call, etc).

Questions:

- What would be the best return type definition for `make_validator`? It is constructed dynamically and there are only 4 classes defined there at the moment. Or it is OK to have a union?
- What about readability? Could this code be improved somehow?
