### PR TITLE
Canonicalise `anyOf` special cases when all subschemas have only the `type` keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Canonicalise `anyOf` special cases when all subschemas have only the `type` keyword
+
 #### 0.18.0 - 2020-09-10
 - Performance improvements from careful caching (#62)
 - Use a validator that corresponds to the input schema draft version (#66)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+#### 0.18.1 - 2020-11-21
 - Canonicalise `anyOf` special cases when all subschemas have only the `type` keyword
 
 #### 0.18.0 - 2020-09-10

--- a/src/hypothesis_jsonschema/__init__.py
+++ b/src/hypothesis_jsonschema/__init__.py
@@ -3,7 +3,7 @@
 The only public API is `from_schema`; check the docstring for details.
 """
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 __all__ = ["from_schema"]
 
 from ._from_schema import from_schema

--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -522,10 +522,12 @@ def canonicalish(schema: JSONType) -> Dict[str, Any]:
             else:
                 break
         else:
-            # All subschemas have only the "type" keyword, then we merge all types into the parent schema
+            # All subschemas have only the "type" keyword, then we merge all types
+            # into the parent schema
             del schema["anyOf"]
             new_types = canonicalish({"type": types})
             schema = merged([schema, new_types])
+            assert isinstance(schema, dict)  # merging was certainly valid
     if "allOf" in schema:
         schema["allOf"] = [
             json.loads(enc)

--- a/tests/test_canonicalise.py
+++ b/tests/test_canonicalise.py
@@ -200,8 +200,26 @@ def test_canonicalises_to_empty(schema):
                     {"anyOf": [{"type": "number"}, {"type": "array"}]},
                 ]
             },
-            # TODO: collapse into {"type": ["string", "number", "array"]}
-            {"anyOf": [{"type": "array"}, {"type": "number"}, {"type": "string"}]},
+            {"type": ["number", "string", "array"]},
+        ),
+        (
+            {
+                "anyOf": [
+                    {"type": "integer"},
+                    {"type": "number"},
+                ]
+            },
+            {"type": "number"},
+        ),
+        (
+            {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "number"},
+                ],
+                "type": ["string", "object"],
+            },
+            {"type": "string"},
         ),
         ({"uniqueItems": False}, {}),
         (


### PR DESCRIPTION
Found one `TODO` entry on this matter :)