### PR TITLE
Improve canonicalisation for conditional keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Improve performance for conditional keywords
+
 #### 0.18.1 - 2020-11-21
 - Canonicalise `anyOf` special cases when all subschemas have only the `type` keyword
 

--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -243,12 +243,13 @@ def canonicalish(schema: JSONType) -> Dict[str, Any]:
     then = schema.pop("then", schema)
     else_ = schema.pop("else", schema)
     if if_ is not None and (then is not schema or else_ is not schema):
-        schema = {
-            "anyOf": [
-                {"allOf": [if_, then, schema]},
-                {"allOf": [{"not": if_}, else_, schema]},
-            ]
-        }
+        if then not in (if_, TRUTHY) or else_ != TRUTHY:
+            schema = {
+                "anyOf": [
+                    {"allOf": [if_, then, schema]},
+                    {"allOf": [{"not": if_}, else_, schema]},
+                ]
+            }
     assert isinstance(schema, dict)
     # Recurse into the value of each keyword with a schema (or list of them) as a value
     for key in SCHEMA_KEYS:

--- a/tests/test_canonicalise.py
+++ b/tests/test_canonicalise.py
@@ -260,6 +260,13 @@ def test_canonicalises_to_empty(schema):
             # TODO: could be {"enum": ["a", "b", "c"]},
             {"anyOf": [{"const": "a"}, {"const": "b"}, {"const": "c"}]},
         ),
+        ({"if": {"type": "null"}, "then": {"type": "null"}}, {}),
+        ({"if": {"type": "null"}, "then": {"type": "null"}, "else": {}}, {}),
+        ({"if": {"type": "null"}, "then": {}, "else": {}}, {}),
+        (
+            {"if": {"type": "integer"}, "then": {}, "else": {}, "type": "number"},
+            {"type": "number"},
+        ),
     ],
 )
 def test_canonicalises_to_expected(schema, expected):


### PR DESCRIPTION
I noticed that some conditional schemas are canonicalised very slow, consider this one:

```python
SCHEMA = {
    "if": {
        "if": {"if": {"type": "null"}, "then": {"type": "null"}},
        "then": {"if": {"type": "null"}, "then": {"type": "null"}},
    },
    "then": {
        "if": {"if": {"type": "null"}, "then": {"type": "null"}},
        "then": {"if": {"type": "null"}, "then": {"type": "null"}},
    },
}
```
On my machine, each `canonicalish` call takes ~ 30ms, but if the "if" schema is equal to "then" and there is no "else" (or it is truthy), then this condition is a no-op.

It is slightly related to #64, where the example was not canonicalised to `{"not": {}}`, with this change it does, but it doesn't solve the general case with `anyOf`, though (as per [your comment](https://github.com/Zac-HD/hypothesis-jsonschema/issues/64#issuecomment-681376875))